### PR TITLE
Explicit include the cstdint header for gcc 13

### DIFF
--- a/tutorials/common/BvhBuilder.h
+++ b/tutorials/common/BvhBuilder.h
@@ -21,6 +21,7 @@
 //
 
 #pragma once
+#include <cstdint>
 #include <cassert>
 #include <queue>
 #include <tutorials/common/Aabb.h>


### PR DESCRIPTION
According to the https://gcc.gnu.org/gcc-13/porting_to.html, gcc 13 doesn't implicitly include `<cstdint>` anymore, so we need to include it explicitly.